### PR TITLE
Remove EOL for encoded hashes

### DIFF
--- a/sdk/src/main/java/com/commutestream/sdk/CommuteStream.java
+++ b/sdk/src/main/java/com/commutestream/sdk/CommuteStream.java
@@ -542,7 +542,7 @@ public class CommuteStream {
         try {
             MessageDigest md = MessageDigest.getInstance(algorithm);
             byte[] hashBytes = md.digest(other.getBytes());
-            hashed = Base64.encodeToString(hashBytes, 0, hashBytes.length, 0);
+            hashed = Base64.encodeToString(hashBytes, 0, hashBytes.length, Base64.NO_WRAP);
         } catch (Exception e) {
             return null;
         }


### PR DESCRIPTION
Avoids an unnecessary and ugly looking EOL (carriage return) character
in our android id hashes.

Fixes #4